### PR TITLE
add autoReboot = true to system.autoUpgrade

### DIFF
--- a/nix/system.nix
+++ b/nix/system.nix
@@ -19,6 +19,7 @@
 
   system.autoUpgrade = {
     enable = true;
+    allowReboot = true;
     flake = "github:acm-uic/simple-ts-clock";
   };
 


### PR DESCRIPTION
This option should enable `autoReboot` so the autoUpgrade doesn't fail and leave the clock on the TTY every 4 AM. I don't have the ability to test, so if you can add my key and I can work on this PR independently.