### PR TITLE
QR Codes for Discord Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ can be run as follows:
 2. Navigate to the repository directory.
 3. Create a `.env` file based on `.env.example`.
 4. Run `npm install` to install dependencies.
+5. Run `npm run build` to make `npm run start` work (I haven't investigated why this is necessary).
 
 ### How to use
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A simple, maybe not so simple clock replacement for the office of ACM@UIC.
 * Time and Date
 * CTA Bus and Train Arrival Times
 * Weather from DarkSky
+* QR Codes for ACM and LUG Discords, and a QR code for the app repository
 
 # Building and deployment
 
@@ -28,6 +29,7 @@ can be run as follows:
 1. Clone the repository.
 2. Navigate to the repository directory.
 3. Create a `.env` file based on `.env.example`.
+4. Optionally modify the values (not the keys) of `src/qrCodeUrls.ts` to point to up-to-date URLs for the Discord and the repository for this project, if they've changed. Please commit those changes.
 4. Run `npm install` to install dependencies.
 5. Run `npm run build` to make `npm run start` work (I haven't investigated why this is necessary).
 
@@ -42,6 +44,9 @@ Offline mode will disable api requests to the server leaving only the clock runn
 
 ### Demo Mode
 Demo mode works like offline mode but displays demo information instead of real data from apis. It can be activated by going to `/demo` path.
+
+### Only QR Codes Mode
+To show only QR codes, got to the `/only-qr-codes` path. This is currently the only way to see the QR codes, but this will change in a future version - they will be visible in all modes.
 
 ### Configuration
 To override the default config, you can use the URL GET parameters or by pressing `c` to open the config options.

--- a/frontend/main.scss
+++ b/frontend/main.scss
@@ -311,6 +311,34 @@ body {
     }
 }
 
+.qrCode {
+    display: none;
+}
+
+#lug-discord-qr-code {
+    position: fixed;
+    top: 490px;
+    left: 543px;
+    width: 450px;
+    height: 450px;
+}
+
+#acm-discord-qr-code {
+    position: fixed;
+    top: 1070px;
+    left: 543px;
+    width: 450px;
+    height: 450px;
+}
+
+#app-repo-qr-code {
+    position: fixed;
+    top: 1660px;
+    left: 720px;
+    width: 150px;
+    height: 150px;
+}
+
 #footer {
     text-align: center;
     font-size: 0.5em;

--- a/frontend/main.ts
+++ b/frontend/main.ts
@@ -47,7 +47,6 @@ window.onload = (): void => {
 
     if (mode !== "only-qr-codes") {
       for (const el of document.getElementsByClassName("qrCode")) {
-        console.log("Hi");
         (el as HTMLElement).style.display = "none";
       }
     }

--- a/frontend/main.ts
+++ b/frontend/main.ts
@@ -44,8 +44,13 @@ window.onload = (): void => {
     const mode = window.location.pathname.split("/")[1];
     updateTime();
     setInterval(updateTime, 5000);
-    
 
+    if (mode !== "only-qr-codes") {
+      for (const el of document.getElementsByClassName("qrCode")) {
+        console.log("Hi");
+        (el as HTMLElement).style.display = "none";
+      }
+    }
     switch (mode) {
         case "demo":
             for (let key in demoData) {
@@ -60,6 +65,14 @@ window.onload = (): void => {
             }
         case "offline":
             document.getElementById(`${mode}Mode`).style.display = "block";
+            break;
+        case "only-qr-codes":
+            for (const el of document.getElementsByClassName("tracker")) {
+              (el as HTMLElement).style.display = "none";
+            }
+            for (const el of document.getElementsByClassName("qrCode")) {
+              (el as HTMLElement).style.display = "inline";
+            }
             break;
         default:
             getData();
@@ -92,5 +105,5 @@ window.onload = (): void => {
 
     setInterval((): void => {
         window.location.reload();
-    }, 7200000); 
+    }, 7200000);
 }

--- a/nix/system.nix
+++ b/nix/system.nix
@@ -65,6 +65,7 @@
       authorizedKeys = {
         keys = [
           "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDoa0YA2ib7vs3VgjivUW1BL/1qVCq6+tMbx91NdDU5EljYYT9ToaGisaT8/OcbmsUAES0t/lDa65v26PWR9yhuj1UJoqVNZfnQTvaGaVaXWrBEY1wEb+bxJNws1xTUzjTwuWkH0uKz/vwpNzAPzMnLGAjcnLcwm4Yvxd9Ec76U835Cl8wI8/f51flHChkPi5HKQSYAR3aM1ZJ+j93pe5XxXA6l5QTDm4+3nmZHzzbYODSAznkTfPQ5F/iXG0xNN3zRaiBcYIbG/MV644U+ycdy7kAB3AMgwjgz2TaChBy5wQt81U7shAQGVY4NKruhXa/gRltYJ7fqkbTT97fQ3Spho1A9/ZtftAFKZAeGfBPHg/WglUFNpbg8LMgCOfUNcfXcNB1DkzorIj41zQuTGoRAB5U3DGbIvayH11v0WRAVpd/+TRjpln2Mr+Idvf7qs+uxUkUR+qVP65GI6dIyWKEsLpRTr85PbrRsNkEThG1F7Yp+bUZ57SpmnWHUob0en3k= chase"
+          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEpwZBQVWu8V8LpEyCYqYEwC6G2tRs4viimz6dlMlNDt samuelskean@Samuels-MacBook-Air.local"
         ];
       };
     };

--- a/nix/system.nix
+++ b/nix/system.nix
@@ -74,12 +74,12 @@
     let
       run = pkgs.writeScriptBin "rotator" ''
         #!/usr/bin/env bash
-        ret=1;  
+        ret=1;
         while test $ret -ne 0; do
               ${pkgs.wlr-randr}/bin/wlr-randr --output DP-3 --transform=90
               ret=$?
-        done 
-        ${pkgs.google-chrome}/bin/google-chrome-stable --disable-http-cache --simulate-outdated-no-au="01 Jan 2099" --kiosk "http://localhost:8080";
+        done
+        ${pkgs.google-chrome}/bin/google-chrome-stable --disable-http-cache --simulate-outdated-no-au="01 Jan 2099" --kiosk "http://localhost:8080/only-qr-codes";
       '';
     in
     {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
         "./views/*"
     ],
     "scripts": {
+      "webpack-help": "webpack-cli --help",
         "clean": "rimraf ./dist/",
-        "build": "npm run build-ts && npm run build-webpack",
+        "build": "npm run build-ts && npm run build-webpack && npm run generate:qr",
+        "generate:qr": "ts-node scripts/generate-qr.ts",
         "build-ts": "tsc",
         "watch-ts": "tsc -w",
         "build-webpack": "webpack-cli --mode production",
@@ -34,6 +36,7 @@
     "homepage": "https://github.com/bmiddha/simple-js-clock#readme",
     "dependencies": {
         "@fortawesome/fontawesome-free": "^6.7.2",
+        "@types/qrcode": "^1.5.5",
         "apicache": "^1.6.3",
         "body-parser": "^1.20.3",
         "compression": "^1.8.0",
@@ -66,6 +69,7 @@
         "node-fetch": "^2.7.0",
         "nodemon": "^3.1.9",
         "prettier": "^3.5.0",
+        "qrcode": "^1.5.4",
         "rimraf": "^6.0.1",
         "sass-loader": "^16.0.4",
         "style-loader": "^4.0.0",

--- a/scripts/generate-qr.ts
+++ b/scripts/generate-qr.ts
@@ -1,0 +1,23 @@
+// samuel-skean: This was copied and pasted from ChatGPT, with minimal modifications. I have audited it, but this is also the first node code I"ve written.
+import QRCode from "qrcode";
+import { mkdirSync, readFileSync, rmSync } from "fs";
+import { resolve } from "path";
+import { qrCodeUrls } from "../src/qrCodeUrls";
+
+
+async function generate() {
+    const qrCodeDirectoryPath = resolve(__dirname, "../dist/public/qr/");
+
+    rmSync(qrCodeDirectoryPath, { recursive: true, force: true });
+    mkdirSync(qrCodeDirectoryPath);
+    for (const [ name, url ] of Object.entries(qrCodeUrls)) {
+        const file = resolve(__dirname, `../dist/public/qr/${name}.svg`);
+        QRCode.toFile(file, url, { type: "svg" });
+        console.log(`✅ QR code generated: ${file}`);
+    }
+}
+
+generate().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -33,6 +33,7 @@ app.get("/", homeController.index);
 app.get("/config", homeController.config);
 app.get("/offline", homeController.offline);
 app.get("/demo", homeController.demo);
+app.get("/only-qr-codes", homeController.onlyQrCodes);
 app.get("/api/ctaBus", ctaBusController.ctaBus);
 app.get("/api/ctaTrain", ctaTrainController.ctaTrain);
 app.get("/api/weather", weatherController.weather);

--- a/src/controllers/homeController.ts
+++ b/src/controllers/homeController.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { qrCodeUrls } from "../qrCodeUrls";
 
 interface ExplictAnyIndex {
     [key: string]: any; // Add index signature
@@ -20,19 +21,14 @@ export let index = (req: Request, res: Response): void => {
 };
 
 export let config = (req: Request, res: Response): void => {
-    res.render("home", {
+  res.locals.qrCodeUrls = qrCodeUrls;
+  res.render("home", {
         title: "Home"
     });
 }
 
-export let offline = (req: Request, res: Response): void => {
-    res.render("home", {
-        title: "Home"
-    });
-}
+export let offline = config;
 
-export let demo = (req: Request, res: Response): void => {
-    res.render("home", {
-        title: "Home"
-    });
-}
+export let demo = config;
+
+export let onlyQrCodes = config;

--- a/src/qrCodeUrls.ts
+++ b/src/qrCodeUrls.ts
@@ -1,0 +1,5 @@
+export const qrCodeUrls = {
+    "acmDiscord": "https://discord.gg/aeN2KPJA",
+    "lugDiscord": "https://discord.gg/GX8ghFch",
+    "appRepo": "https://github.com/acm-uic/simple-ts-clock"
+};

--- a/views/home.pug
+++ b/views/home.pug
@@ -20,6 +20,7 @@ block content
         input.btn(type="button",value="Load Defaults",onClick="window.location.href='/'")
         input.btn(type="button",value="Offline Mode",onClick="window.location.href='/offline'")
         input.btn(type="button",value="Demo Mode",onClick="window.location.href='/demo'")
+        input.btn(type="button",value="Only QR Codes",onClick="window.location.href='/only-qr-codes'")
     script.
         const paramsString = window.location.href.split("?")[1];
         const searchParams = new URLSearchParams(paramsString);
@@ -34,9 +35,21 @@ block content
   #time
   #date
   #weather
-  #messages
-  #switcher
-    #transit
-      #cta
-        ul#bus
-        ul#train
+  #messages.tracker
+  #switcher.tracker
+    #transit.tracker
+      #cta.tracker
+        ul#bus.tracker
+        ul#train.tracker
+
+  div.qrCode(style="position: fixed; top: 490px; left: 100px; font-size: 1.3em;") ACM Discord:
+
+    a.qrCode(href=qrCodeUrls['acmDiscord'])
+      img.qrCode#lug-discord-qr-code(src="/qr/acmDiscord.svg" alt="QR code for ACM Discord Server")
+  div.qrCode(style="position: fixed; top: 1070px; left: 100px; font-size: 1.3em;") LUG Discord:
+
+    a.qrCode(href=qrCodeUrls['lugDiscord'])
+      img.qrCode#acm-discord-qr-code(src="/qr/lugDiscord.svg" alt="QR code for LUG Discord Server")
+
+  a.qrCode(href=qrCodeUrls['appRepo'])
+    img.qrCode#app-repo-qr-code(src="/qr/appRepo.svg" alt="QR code for the repository for this app")


### PR DESCRIPTION
Please see commit messages for more information.
Especially the commit message for [this commit](https://github.com/acm-uic/simple-ts-clock/pull/15/commits/5dbda7f4fd91cdce0f33f811097fad8382a35a65), which (should) cause the page displayed on the screen to change to the screen I authored in this set of commits.

Note: The QR codes currently make it look like *I* (Discord user `@skean.2`) am inviting people to the servers. To change the URLs, just edit the URLs in `src/qrCodeUrls.ts` and the new URLs will be used for the QR codes on the next build + deploy.