### PR TITLE
Whoops, fixed qrcode display.

### DIFF
--- a/frontend/main.ts
+++ b/frontend/main.ts
@@ -71,7 +71,7 @@ window.onload = (): void => {
             (el as HTMLElement).style.display = "none";
           }
           for (const el of document.getElementsByClassName("qrCode")) {
-            (el as HTMLElement).style.display = "";
+            (el as HTMLElement).style.display = "block";
           }
           break; 
         default:


### PR DESCRIPTION
My last change was too hasty - it caused the QR codes to be invisible. This one should still satisfy those who only want `display: inline` used for text, while also working.