### PR TITLE
Made QR code CSS less jank.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ Offline mode will disable api requests to the server leaving only the clock runn
 ### Demo Mode
 Demo mode works like offline mode but displays demo information instead of real data from apis. It can be activated by going to `/demo` path.
 
-### Only QR Codes Mode
-To show only QR codes, got to the `/only-qr-codes` path. This is currently the only way to see the QR codes, but this will change in a future version - they will be visible in all modes.
-
 ### Configuration
 To override the default config, you can use the URL GET parameters or by pressing `c` to open the config options.
 

--- a/frontend/main.scss
+++ b/frontend/main.scss
@@ -9,7 +9,7 @@
 body {
     margin: 0;
     font-family: Montserrat, sans-serif;
-    font-size: 3em;
+    font-size: 2.5em;
     color: #ffffff;
     background: linear-gradient(-45deg, #ee7752, #e73c7e, #23a6d5, #23d5ab);
     background-size: 400% 400%;
@@ -92,7 +92,8 @@ ul {
             input {
                 border-bottom: 1px solid;
             }
-            label, input {
+            label,
+            input {
                 display: block;
                 color: inherit;
                 width: 500px;
@@ -134,9 +135,9 @@ body {
     max-height: 100%;
     border: 1px solid #000000;
     display: grid;
-    grid-template-areas: 'time time time weather weather' 'date date date date date' 'messages messages messages messages messages' 'switcher switcher switcher switcher switcher' 'footer footer footer footer footer';
+    grid-template-areas: 'time time time weather weather' 'date date date date date' 'acm-discord-qr-code-label acm-discord-qr-code lug-discord-qr-code-label lug-discord-qr-code messages' 'switcher switcher switcher switcher switcher' 'footer footer footer footer footer';
     grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
-    grid-template-rows: 0.75fr 0.3fr 0.9fr 4.1fr 0.18fr;
+    grid-template-rows: 0.6fr 0.2fr 0.9fr 4fr 0.18fr;
     #time {
         grid-area: time;
     }
@@ -148,10 +149,27 @@ body {
     }
     #switcher {
         grid-area: switcher;
-	overflow: hidden;
+        overflow: hidden;
     }
-    #messages {
-        grid-area: messages;
+    #acm-discord-qr-code-label {
+        grid-area: acm-discord-qr-code-label;
+        place-self: center;
+        line-height: inherit;
+        text-align: center;
+    }
+    #acm-discord-qr-code {
+        grid-area: acm-discord-qr-code;
+        place-self: center;
+    }
+    #lug-discord-qr-code-label {
+        grid-area: lug-discord-qr-code-label;
+        place-self: center;
+        line-height: inherit;
+        text-align: center;
+    }
+    #lug-discord-qr-code {
+        grid-area: lug-discord-qr-code;
+        place-self: center;
     }
     #footer {
         grid-area: footer;
@@ -160,6 +178,7 @@ body {
 
 // Switcher
 #switcher {
+    margin: 0px 0px 100px 0px;
     position: relative;
     & > div {
         width: 100%;
@@ -302,80 +321,13 @@ body {
     }
 }
 
-.qrCodeLabel {
-    font-size: 1em;
-    position: absolute;
-    top: 468px;
-}
-
-#acm-discord-qr-code-label {
-	left: 103px;
-}
-
-#lug-discord-qr-code-label {
-	left: 606px;
-}
-
-.onlyQrCodes.qrCodeLabel {
-    position: fixed;
-    left: 100px;
-    font-size: 3em;
-}
-
-.onlyQrCodes.acm-discord-qr-code-label {
-    top: 490px;
-}
-
-.onlyQrCodes.lug-discord-qr-code-label {
-    top: 1070px;
-}
-
-a.qrCode {
-    top: 409px;
-}
-
 img.qrCode {
     width: 200px;
-	height: 200px;
-}
-
-.acm-discord-qr-code {
-	position: absolute;
-	left: 277px;
-}
-
-.lug-discord-qr-code {
-	position: absolute;
-	left: 776px;
+    height: 200px;
 }
 
 #app-repo-qr-code {
     display: none;
-}
-
-.onlyQrCodes img.qrCode {
-    width: 450px;
-	height: 450px;
-}
-
-.onlyQrCodes a.acm-discord-qr-code {
-	position: absolute;
-	top: 527px;
-	left: 493px;
-}
-
-.onlyQrCodes .lug-discord-qr-code {
-	position: absolute;
-	top: 1100px;
-	left: 493px;
-}
-
-.onlyQrCodes #app-repo-qr-code {
-    position: absolute;
-    top: 1660px;
-    left: 720px;
-    width: 150px;
-    height: 150px;
 }
 
 #footer {

--- a/frontend/main.ts
+++ b/frontend/main.ts
@@ -39,17 +39,10 @@ function switcher(): void {
     counter++;
 }
 
-
 window.onload = (): void => {
     const mode = window.location.pathname.split("/")[1];
     updateTime();
     setInterval(updateTime, 5000);
-
-    if (mode !== "only-qr-codes") {
-      for (const el of document.getElementsByClassName("qrCode")) {
-        (el as HTMLElement).classList.remove("onlyQrCodes");
-      }
-    } 
 
     switch (mode) {
         case "demo":
@@ -66,16 +59,6 @@ window.onload = (): void => {
         case "offline":
             document.getElementById(`${mode}Mode`).style.display = "block";
             break;
-        case "only-qr-codes":
-          for (const el of document.getElementsByClassName("tracker")) {
-            (el as HTMLElement).style.display = "none";
-          }
-          for (const el of document.getElementsByClassName("qrCode")) {
-            (el as HTMLElement).style.display = "block";
-            (el as HTMLElement).classList.add("onlyQrCodes");
-          }
-          
-          break; 
         default:
             getData();
             setInterval(getData, 120000);

--- a/src/app.ts
+++ b/src/app.ts
@@ -33,7 +33,6 @@ app.get("/", homeController.index);
 app.get("/config", homeController.config);
 app.get("/offline", homeController.offline);
 app.get("/demo", homeController.demo);
-app.get("/only-qr-codes", homeController.onlyQrCodes);
 app.get("/api/ctaBus", ctaBusController.ctaBus);
 app.get("/api/ctaTrain", ctaTrainController.ctaTrain);
 app.get("/api/weather", weatherController.weather);

--- a/src/controllers/homeController.ts
+++ b/src/controllers/homeController.ts
@@ -20,15 +20,14 @@ export let index = (req: Request, res: Response): void => {
     }
 };
 
-export let onlyQrCodes = (req: Request, res: Response): void => {
+export let config = (req: Request, res: Response): void => {
   res.locals.qrCodeUrls = qrCodeUrls;
   res.render("home", {
     title: "Home"
   });
 }
 
-export let config = onlyQrCodes;
 
-export let offline = onlyQrCodes;
+export let offline = config;
 
-export let demo = onlyQrCodes;
+export let demo = config;

--- a/views/home.pug
+++ b/views/home.pug
@@ -20,7 +20,6 @@ block content
         input.btn(type="button",value="Load Defaults",onClick="window.location.href='/'")
         input.btn(type="button",value="Offline Mode",onClick="window.location.href='/offline'")
         input.btn(type="button",value="Demo Mode",onClick="window.location.href='/demo'")
-        input.btn(type="button",value="Only QR Codes",onClick="window.location.href='/only-qr-codes'")
     script.
         const paramsString = window.location.href.split("?")[1];
         const searchParams = new URLSearchParams(paramsString);
@@ -43,10 +42,10 @@ block content
         ul#train.tracker
   
   div.qrCode.qrCodeLabel#acm-discord-qr-code-label ACM:
-  a.qrCode.acm-discord-qr-code(href=qrCodeUrls['acmDiscord'])
+  a.qrCode#acm-discord-qr-code(href=qrCodeUrls['acmDiscord'])
     img.qrCode(src="/qr/acmDiscord.png" alt="QR code for ACM Discord Server")
   div.qrCode.qrCodeLabel#lug-discord-qr-code-label LUG:
-  a.qrCode.lug-discord-qr-code(href=qrCodeUrls['lugDiscord'])
+  a.qrCode#lug-discord-qr-code(href=qrCodeUrls['lugDiscord'])
     img.qrCode(src="/qr/lugDiscord.png" alt="QR code for LUG Discord Server")
   a.qrCode(href=qrCodeUrls['appRepo'])
     img.qrCode#app-repo-qr-code(src="/qr/appRepo.png" alt="QR code for the repository for this app")


### PR DESCRIPTION
Also, removed `only-qr-codes/` endpoint and made the tracker one row shorter (avoiding collision with the footer).
Ideally this also prevents horrible shenanigans with the qr codes covering up the date. It almost certainly will, but I can't test it because I don't have the weather API key :(.