### PR TITLE
Nix Github action.

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -10,5 +10,5 @@ buildNpmPackage rec {
 
   src = ../.;
 
-  npmDepsHash = "sha256-9Bvg82lAgnbzs2XwZBE+2YCjbqIEiV2PkEqjkis0qiI=";
+  npmDepsHash = "sha256-1Bvg82lAgnbzs2XwZBE+2YCjbqIEiV2PkEqjkis0qiI=";
 }


### PR DESCRIPTION
Catches bad `npmDepsHash` values at PR time (or before).